### PR TITLE
Msg utf8

### DIFF
--- a/aw_notify/main.py
+++ b/aw_notify/main.py
@@ -21,7 +21,7 @@ from typing import (
 import aw_client.queries
 import click
 from aw_core.log import setup_logging
-from desktop_notifier import DesktopNotifier
+from desktop_notifier import DesktopNotifierSync
 from typing_extensions import TypeAlias
 
 logger = logging.getLogger(__name__)
@@ -46,7 +46,7 @@ td8h = timedelta(hours=8)
 # global objects
 # will init in entrypoints
 aw: Optional[AwClient] = None
-notifier: Optional[DesktopNotifier] = None
+notifier: Optional[DesktopNotifierSync] = None
 
 # executable path
 script_dir = Path(__file__).parent.absolute()
@@ -145,14 +145,14 @@ def notify(title: str, msg: str):
 
     global notifier
     if notifier is None:
-        notifier = DesktopNotifier(
+        notifier = DesktopNotifierSync(
             app_name="AW",
             app_icon=f"file://{icon_path}",
             notification_limit=10,
         )
 
     logger.info(f'Showing: "{title} - {msg}"')
-    notifier.send_sync(title=title, message=msg)
+    notifier.send(title=title, message=msg)
 
 
 class CategoryAlert:

--- a/aw_notify/main.py
+++ b/aw_notify/main.py
@@ -21,7 +21,7 @@ from typing import (
 import aw_client.queries
 import click
 from aw_core.log import setup_logging
-from desktop_notifier import DesktopNotifierSync
+from desktop_notifier import DesktopNotifierSync, Icon
 from typing_extensions import TypeAlias
 
 logger = logging.getLogger(__name__)
@@ -147,7 +147,7 @@ def notify(title: str, msg: str):
     if notifier is None:
         notifier = DesktopNotifierSync(
             app_name="AW",
-            app_icon=f"file://{icon_path}",
+            app_icon=Icon(uri=f"file://{icon_path}"),
             notification_limit=10,
         )
 

--- a/aw_notify/main.py
+++ b/aw_notify/main.py
@@ -347,6 +347,7 @@ def send_checkin(title="Time today", date=None):
 
     msg = ""
     msg += "\n".join(f"- {c}: {t}" for c, t in top_categories)
+    msg = msg.encode('utf-8').decode('unicode_escape')
     if msg:
         notify(title, msg)
     else:


### PR DESCRIPTION
How to set the entry name in Chinese so that notifications will be displayed as Unicode escape sequences. Other languages may also have this issue, and perhaps there are related problems in other parts of the project as well. I only modified the notification here

```bash
Showing: "Time yesterday - - All: 4h 16m
- Uncategorized: 2h 7m
- \u5de5\u4f5c: 2h 6m"  (aw_notify.main:154)
```

```bash
Showing: "Time yesterday - - All: 4h 18m
- Uncategorized: 2h 8m
- 工作: 2h 7m"  (aw_notify.main:154)
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Unicode display issue in notifications by encoding and decoding messages and replaces `DesktopNotifier` with `DesktopNotifierSync` for synchronous sending.
> 
>   - **Behavior**:
>     - Fixes Unicode display issue in notifications by encoding and decoding message in `send_checkin()` and `send_checkin_yesterday()`.
>     - Replaces `DesktopNotifier` with `DesktopNotifierSync` in `notify()` to ensure synchronous notification sending.
>   - **Imports**:
>     - Imports `DesktopNotifierSync` and `Icon` from `desktop_notifier`.
>   - **Misc**:
>     - Updates `notify()` function to use `Icon` for `app_icon` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-notify&utm_source=github&utm_medium=referral)<sup> for d3d005852e361ce43b109ccf45609264edb10f70. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->