### PR TITLE
fix: decode unicode escape sequences (fixes emojis, Chinese, etc)

### DIFF
--- a/aw_notify/main.py
+++ b/aw_notify/main.py
@@ -331,6 +331,25 @@ def checkin(testing=False):
     send_checkin()
 
 
+def decode_unicode_escapes(s: str):
+    """
+    Decodes any Unicode escape sequences present in the input string 
+    and returns the decoded result.
+
+    Args:
+        s (str): The input string which may contain Unicode escape sequences.
+
+    Returns:
+        str: The decoded string where Unicode escape sequences have been converted
+             to their corresponding characters.
+
+    Example:
+        Input: "\\u5de5\\u4f5c"
+        Output: "工作"
+    """
+    return s.encode('utf-8').decode('unicode_escape')
+
+
 def send_checkin(title="Time today", date=None):
     """
     Sends a summary notification of the day.
@@ -346,7 +365,7 @@ def send_checkin(title="Time today", date=None):
     ][:4]
 
     msg = ""
-    msg += "\n".join(f"- {c}: {t}" for c, t in top_categories)
+    msg += "\n".join(f"- {decode_unicode_escapes(c)}: {t}" for c, t in top_categories)
     if msg:
         notify(title, msg)
     else:

--- a/aw_notify/main.py
+++ b/aw_notify/main.py
@@ -331,22 +331,13 @@ def checkin(testing=False):
     send_checkin()
 
 
-def decode_unicode_escapes(s: str):
+def decode_unicode_escapes(s: str) -> str:
     """
     Decodes any Unicode escape sequences present in the input string 
     and returns the decoded result.
-
-    Args:
-        s (str): The input string which may contain Unicode escape sequences.
-
-    Returns:
-        str: The decoded string where Unicode escape sequences have been converted
-             to their corresponding characters.
-
-    Example:
-        Input: "\\u5de5\\u4f5c"
-        Output: "工作"
     """
+    # see https://github.com/ActivityWatch/aw-notify/pull/6#issue-2607074123
+    # assert "工作" == decode_unicode_escapes("\\u5de5\\u4f5c")
     return s.encode('utf-8').decode('unicode_escape')
 
 

--- a/aw_notify/main.py
+++ b/aw_notify/main.py
@@ -336,7 +336,7 @@ def decode_unicode_escapes(s: str) -> str:
     Decodes any Unicode escape sequences present in the input string 
     and returns the decoded result.
     """
-    # see https://github.com/ActivityWatch/aw-notify/pull/6#issue-2607074123
+    # see https://github.com/ActivityWatch/aw-notify/pull/6
     # assert "工作" == decode_unicode_escapes("\\u5de5\\u4f5c")
     return s.encode('utf-8').decode('unicode_escape')
 


### PR DESCRIPTION
set the category name in Chinese so that notifications will be displayed as Unicode escape sequences. Other languages may also have this issue, and perhaps there are related problems in other parts of the project as well. I only modified the notification here

```bash
Showing: "Time yesterday - - All: 4h 16m
- Uncategorized: 2h 7m
- \u5de5\u4f5c: 2h 6m"  (aw_notify.main:154)
```

```bash
Showing: "Time yesterday - - All: 4h 18m
- Uncategorized: 2h 8m
- 工作: 2h 7m"  (aw_notify.main:154)
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Chinese character display issue in notifications by decoding Unicode escape sequences in `main.py`.
> 
>   - **Behavior**:
>     - Fixes issue with Chinese characters in category names being displayed as Unicode escape sequences in notifications.
>     - Modifies `send_checkin` in `main.py` to decode Unicode escape sequences using `decode_unicode_escapes()`.
>   - **Functions**:
>     - Adds `decode_unicode_escapes()` to `main.py` to convert Unicode escape sequences to characters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-notify&utm_source=github&utm_medium=referral)<sup> for bd29ee5ed092fef00a92944b6d3d6efb8bf08d3e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->